### PR TITLE
Added standalone plotting of arriba output

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -65,14 +65,23 @@ logdir: ~
 #   skip: false
 #   # Minimum number of callers for fusion to be reported [integer]
 #   tools_cutoff: 1
-#   # Path to references used by Arriba in standalone mode [path]
-#   arriba_standalone_refs: ~
 #   # Path to rnafusion references [path]
 #   genomes_base: ~
 #   # URL to use for nf-core/rnafusion [string]
 #   nf_url: "https://github.com/nf-core/rnafusion"
 #   # Tag to use for nf-core/rnafusion [string]
 #   nf_tag: "3.0.1"
+#   arriba_standalone:
+#     # Arriba cytobands file for standalone visualisation (Autodetect from nf-core/rnafusion by default) [path]
+#     cytobands: ~
+#     # Code to run before Arriba standalone visualisation [string]
+#     init: ""
+#     # Number of threads for standalone Arriba visualsation (For samtools index and sort) [integer]
+#     threads: 12
+#     # GTF annotation for Arriba standalone visualisation (Autodetect from nf-core/rnafusion by default) [path]
+#     annotation: ~
+#     # Arriba protein domains file for standalone visualisation (Autodetect from nf-core/rnafusion by default) [path]
+#     protein_domains: ~
 # qlucore:
 #   # Skip qlucore mapping [boolean]
 #   skip: false
@@ -104,9 +113,9 @@ logdir: ~
 #     # Body of the mail (jinja2 template) [string]
 #     body: |
 #       # {{ config.analysis }}
-# 
+#
 #       Analysis has started for {{ samples.unique_ids|length }} sample(s).
-# 
+#
 #       🔎 The following samples are being analyzed:
 #       |      ID     |  Run(s)  |
 #       | ----------- | -------- |
@@ -129,9 +138,9 @@ logdir: ~
 #     # Body of the mail (jinja2 template, supports markdown) [string]
 #     body: |
 #       # {{ config.analysis }}
-# 
+#
 #       {{ samples.unique_ids|length }} sample(s) have been processed.
-# 
+#
 #       {% if samples.failed -%}
 #       ❗️ Analysis failed for the following samples:
 #       |      ID     |  Run(s)  |
@@ -144,10 +153,10 @@ logdir: ~
 #       {%- endfor %}
 #       📋 See attached log for more information
 #       {% endif -%}
-# 
+#
 #       {%- if samples.complete -%}
 #       ✅ Analysis completed successfully for the following samples:
-# 
+#
 #       |      ID     |  Run(s)  |
 #       | ----------- | -------- |
 #       {%- for id_, group in samples.complete.split(by="id") %}
@@ -156,7 +165,7 @@ logdir: ~
 #       `{{ sample.run }}`{% if not loop.last %}, {% else %} | {% endif %}
 #       {%- endfor -%}
 #       {%- endfor %}
-# 
+#
 #       {%- endif -%}
 #   smtp:
 #     # SMTP host [string]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -65,6 +65,8 @@ logdir: ~
 #   skip: false
 #   # Minimum number of callers for fusion to be reported [integer]
 #   tools_cutoff: 1
+#   # Path to references used by Arriba in standalone mode [path]
+#   arriba_standalone_refs: ~
 #   # Path to rnafusion references [path]
 #   genomes_base: ~
 #   # URL to use for nf-core/rnafusion [string]

--- a/modules/rnafusion.py
+++ b/modules/rnafusion.py
@@ -1,9 +1,12 @@
 """Module for running nf-core/rnafusion."""
 
+from json import loads
 from logging import LoggerAdapter
 from pathlib import Path
 
 from cellophane import Checkpoints, Config, Executor, Samples, output, runner
+from mpire.async_result import AsyncResult
+from ruamel.yaml import YAML
 
 from modules.common import nf_config
 from modules.nextflow import nextflow
@@ -125,22 +128,64 @@ def _standalone_arriba_visualisation(
     executor: Executor,
     workdir: Path,
     root: Path,
+    logger: LoggerAdapter,
     **kwargs,
 ) -> None:
+    logger.info("Generating standalone arriba visualisations")
 
-    result, _ = executor.submit(
-        str(root / "scripts" / "arriba_draw_fusions.sh"),
-        f"-B {workdir}/arriba:/output",
-        f"-B {config.rnafusion.arriba_standalone_refs}/references:ro",
-        f"-B {workdir}/arriba/{samples}.arriba.fusions.tsv:/fusions.tsv:ro",
-        f"-B {workdir}/star_for_starfusion/{samples}.Aligned.sortedByCoord.out.bam:/Aligned.sortedByCoord.out.bam:ro",
-        f"-B {workdir}/star_for_starfusion/{samples}.Aligned.sortedByCoord.out.bam.bai:/Aligned.sortedByCoord.out.bam.bai:ro",
-        workdir=workdir,
-        name="standalone_arriba_visualisation",
-        **kwargs,
+    try:
+        params_glob = (workdir / "pipeline_info").glob("params_*.json")
+        versions_glob = (workdir / "pipeline_info").glob("software_versions.yml")
+        params_json = next(params_glob)
+        versions_yml = next(versions_glob)
+        params = loads(params_json.read_text())
+        versions = YAML(typ="safe").load(versions_yml)
+    except Exception:
+        params = {}
+        versions = {}
+
+    cytobands, protein_domains, annotation, version = (
+        config.rnafusion.arriba_standalone.get("cytobands")
+        or params.get("arriba_ref_cytobands"),
+        config.rnafusion.arriba_standalone.get("protein_domains")
+        or params.get("arriba_ref_protein_domains"),
+        config.rnafusion.arriba_standalone.get("annotation") or params.get("gtf"),
+        config.rnafusion.arriba_standalone.get("version")
+        or versions.get("ARRIBA_VISUALISATION", {}).get("arriba"),
     )
 
-    result.get()
+    if not (cytobands and protein_domains and annotation and version):
+        logger.warning("Unable to detect params for standalone arriba visualisation")
+        return
+
+    results: list[AsyncResult] = []
+
+    for _id in samples.unique_ids:
+        if not (workdir / "arriba" / f"{_id}.arriba.fusions.tsv").exists():
+            logger.warning(f"No arriba fusions found for sample {_id}")
+            continue
+
+        result, _ = executor.submit(
+            str(root / "scripts" / "arriba_draw_fusions.sh"),
+            env={
+                "_ARRIBA_STANDALONE_FUSIONS": f"{workdir}/arriba/{_id}.arriba.fusions.tsv",
+                "_ARRIBA_STANDALONE_BAM": f"{workdir}/star_for_arriba/{_id}.Aligned.out.bam",
+                "_ARRIBA_STANDALONE_OUTPUT": f"{workdir}/arriba_visualisation/{_id}_standalone_arriba_visualisation.pdf",
+                "_ARRIBA_STANDALONE_CYTOBANDS": str(cytobands),
+                "_ARRIBA_STANDALONE_PROTEIN_DOMAINS": str(protein_domains),
+                "_ARRIBA_STANDALONE_ANNOTATION": str(annotation),
+                "_ARRIBA_STANDALONE_THREADS": config.rnafusion.arriba_standalone.threads,
+            },
+            workdir=workdir,
+            name=f"standalone_arriba_visualisation_{_id}",
+            conda_spec={"dependencies": [f"arriba ={version}", "samtools =1.16"]},
+            cpus=config.rnafusion.arriba_standalone.threads,
+            **kwargs,
+        )
+        results.append(result)
+
+    for result in results:
+        result.get()
 
 
 @output(
@@ -149,11 +194,11 @@ def _standalone_arriba_visualisation(
     checkpoint="DUMMY",
 )
 @output(
-    "arriba/{sample.id}.*",
+    "arriba_visualisation/{sample.id}_standalone_arriba_visualisation.pdf",
     dst_dir="{sample.id}_{sample.last_run}/arriba",
 )
 @output(
-    "arriba/fusions.pdf",
+    "arriba/{sample.id}.*",
     dst_dir="{sample.id}_{sample.last_run}/arriba",
 )
 @output(
@@ -255,6 +300,7 @@ def rnafusion(
         config=config,
         executor=executor,
         root=root,
+        logger=logger,
     )
 
     checkpoints.main.store(rnafusion_nf_config)

--- a/modules/rnafusion.py
+++ b/modules/rnafusion.py
@@ -119,6 +119,30 @@ def _pipeline_args(config: Config, workdir: Path, nf_samples: Path, /):
     ]
 
 
+def _standalone_arriba_visualisation(
+    samples: Samples,
+    config: Config,
+    executor: Executor,
+    workdir: Path,
+    root: Path,
+    **kwargs,
+) -> None:
+
+    result, _ = executor.submit(
+        str(root / "scripts" / "arriba_draw_fusions.sh"),
+        f"-B {workdir}/arriba:/output",
+        f"-B {config.rnafusion.arriba_standalone_refs}/references:ro",
+        f"-B {workdir}/arriba/{samples}.arriba.fusions.tsv:/fusions.tsv:ro",
+        f"-B {workdir}/star_for_starfusion/{samples}.Aligned.sortedByCoord.out.bam:/Aligned.sortedByCoord.out.bam:ro",
+        f"-B {workdir}/star_for_starfusion/{samples}.Aligned.sortedByCoord.out.bam.bai:/Aligned.sortedByCoord.out.bam.bai:ro",
+        workdir=workdir,
+        name="standalone_arriba_visualisation",
+        **kwargs,
+    )
+
+    result.get()
+
+
 @output(
     "arriba_visualisation/{sample.id}_combined_fusions_arriba_visualisation.pdf",
     dst_dir="{sample.id}_{sample.last_run}",
@@ -126,6 +150,10 @@ def _pipeline_args(config: Config, workdir: Path, nf_samples: Path, /):
 )
 @output(
     "arriba/{sample.id}.*",
+    dst_dir="{sample.id}_{sample.last_run}/arriba",
+)
+@output(
+    "arriba/fusions.pdf",
     dst_dir="{sample.id}_{sample.last_run}/arriba",
 )
 @output(
@@ -219,6 +247,14 @@ def rnafusion(
         workdir=workdir,
         logger=logger,
         log_tag=log_tag,
+    )
+
+    _standalone_arriba_visualisation(
+        samples=samples,
+        workdir=workdir,
+        config=config,
+        executor=executor,
+        root=root,
     )
 
     checkpoints.main.store(rnafusion_nf_config)

--- a/schema.yaml
+++ b/schema.yaml
@@ -111,7 +111,7 @@ properties:
     type: object
     oneOf:
     - properties: {skip: {const: true}}
-    - required: [genomes_base, arriba_blacklist, arriba_protein_domain]
+    - required: [genomes_base, arriba_standalone_refs]
     properties:
       skip:
         type: boolean
@@ -131,6 +131,10 @@ properties:
       genomes_base:
         type: path
         description: Path to rnafusion references
+
+      arriba_standalone_refs:
+        type: path
+        description: Path to references used by Arriba in standalone mode
 
       tools_cutoff:
         type: integer

--- a/schema.yaml
+++ b/schema.yaml
@@ -111,7 +111,7 @@ properties:
     type: object
     oneOf:
     - properties: {skip: {const: true}}
-    - required: [genomes_base, arriba_standalone_refs]
+    - required: [genomes_base]
     properties:
       skip:
         type: boolean
@@ -132,9 +132,26 @@ properties:
         type: path
         description: Path to rnafusion references
 
-      arriba_standalone_refs:
-        type: path
-        description: Path to references used by Arriba in standalone mode
+      arriba_standalone:
+        type: object
+        properties:
+          cytobands:
+            type: path
+            description: Arriba cytobands file for standalone visualisation (Autodetect from nf-core/rnafusion by default)
+          protein_domains:
+            type: path
+            description: Arriba protein domains file for standalone visualisation (Autodetect from nf-core/rnafusion by default)
+          annotation:
+            type: path
+            description: GTF annotation for Arriba standalone visualisation (Autodetect from nf-core/rnafusion by default)
+          threads:
+            type: integer
+            description: Number of threads for standalone Arriba visualsation (For samtools index and sort)
+            default: 12
+          init:
+            type: string
+            description: Code to run before Arriba standalone visualisation
+            default: ""
 
       tools_cutoff:
         type: integer

--- a/scripts/arriba_draw_fusions.sh
+++ b/scripts/arriba_draw_fusions.sh
@@ -1,0 +1,2 @@
+set -veo pipefail
+apptainer exec $@ docker://uhrigs/arriba:2.4.0 draw_fusions.sh

--- a/scripts/arriba_draw_fusions.sh
+++ b/scripts/arriba_draw_fusions.sh
@@ -1,2 +1,29 @@
+#!/bin/bash
+
 set -veo pipefail
-apptainer exec $@ docker://uhrigs/arriba:2.4.0 draw_fusions.sh
+
+eval ${_ARRIBA_STANDALONE_INIT}
+
+bam_input_base=$(basename ${_ARRIBA_STANDALONE_BAM} .out.bam)
+bam_input_temp=${TMPDIR}/${bam_input_base}.out.bam
+bam_output_temp=${TMPDIR}/${bam_input_base}.sortedByCoord.out.bam
+
+cp ${_ARRIBA_STANDALONE_BAM} ${bam_input_temp}
+
+samtools sort \
+    -@ ${_ARRIBA_STANDALONE_THREADS} \
+    -o "${bam_output_temp}" \
+    "${bam_input_temp}"
+
+samtools index \
+    -@ ${_ARRIBA_STANDALONE_THREADS} \
+    "${bam_output_temp}"
+
+mkdir -p $(dirname ${_ARRIBA_STANDALONE_OUTPUT})
+draw_fusions.R \
+    --fusions="${_ARRIBA_STANDALONE_FUSIONS}" \
+    --alignments="${bam_output_temp}" \
+    --output="${_ARRIBA_STANDALONE_OUTPUT}" \
+    --annotation="${_ARRIBA_STANDALONE_ANNOTATION}" \
+    --cytobands="${_ARRIBA_STANDALONE_CYTOBANDS}" \
+    --proteinDomains="${_ARRIBA_STANDALONE_PROTEIN_DOMAINS}"


### PR DESCRIPTION
## Contents
Review deadline: 2024-09-30

Main reviewer: @fannyhb

### The What
Added standalone plotting of arriba output. Previously the output of the several fusion callers was merged while plotting. This has not been changed, but now the results of the arriba fusion detection are plotted individually.  

### The Why
Request from the clinicians who look at the qd_rna output to have a plot that only shows arriba output. The merged plot loses some information on the reading frame. 

### The How
Calling function to plot standalone arriba results to the rnafusion runner in modules/rnafusion.py. Defined function with parameters in modules/nextflow/src/util.py. Created script with command to run arriba using a container - modules/nextflow/src/run_arriba.sh. Added lines to import created function in modules/nextflow/__init__.py

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
Run workflow for a few samples

### Installation and initiation

### Tests

### Expected outcome
Standalone arriba plot is saved to arriba/fusions.pdf

## Verifications
- [ ] Code reviewed by @fannyhb
- [ ] Code tested by @fannyhb
