### PR TITLE
Adding timestamp to rsynced output in resultsdir

### DIFF
--- a/modules/qlucore.py
+++ b/modules/qlucore.py
@@ -232,17 +232,17 @@ def _pipeline_args(
 
 @output(
     "starfusion/{sample.id}.*.tsv",
-    dst_dir="{sample.id}_{sample.last_run}/qlucore",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/qlucore",
 )
 @output(
     "star_for_starfusion/{sample.id}.Aligned.sortedByCoord.out.downsampled.bam",
-    dst_dir="{sample.id}_{sample.last_run}/qlucore",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/qlucore",
     checkpoint="downsample_{sample.id}",
     optional=True,
 )
 @output(
     "{sample.id}.qlucore.txt",
-    dst_dir="{sample.id}_{sample.last_run}/qlucore",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/qlucore",
     checkpoint="qlucore",
 )
 @runner(split_by="id")

--- a/modules/rnafusion.py
+++ b/modules/rnafusion.py
@@ -191,48 +191,48 @@ def _standalone_arriba_visualisation(
 
 @output(
     "arriba_visualisation/{sample.id}_combined_fusions_arriba_visualisation.pdf",
-    dst_dir="{sample.id}_{sample.last_run}",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S",
     checkpoint="DUMMY",
 )
 @output(
     "arriba_visualisation/{sample.id}_standalone_arriba_visualisation.pdf",
-    dst_dir="{sample.id}_{sample.last_run}/arriba",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/arriba",
 )
 @output(
     "arriba/{sample.id}.*",
-    dst_dir="{sample.id}_{sample.last_run}/arriba",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/arriba",
 )
 @output(
     "fusioncatcher/{sample.id}.*",
-    dst_dir="{sample.id}_{sample.last_run}/fusioncatcher",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/fusioncatcher",
 )
 @output(
     "starfusion/{sample.id}.*",
-    dst_dir="{sample.id}_{sample.last_run}/starfusion",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/starfusion",
 )
 @output(
     "fusionreport/{sample.id}",
-    dst_name="{sample.id}_{sample.last_run}/fusionreport",
+    dst_name="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/fusionreport",
 )
 @output(
     "{sample.id}.fusionreport.html",
-    dst_dir="{sample.id}_{sample.last_run}",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S",
 )
 @output(
     "fusioninspector/{sample.id}.*",
-    dst_dir="{sample.id}_{sample.last_run}/fusioninspector",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/fusioninspector",
 )
 @output(
     "star_for_starfusion/{sample.id}.Aligned.sortedByCoord.out.bam",
-    dst_dir="{sample.id}_{sample.last_run}",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S",
 )
 @output(
     "star_for_starfusion/{sample.id}.Aligned.sortedByCoord.out.bam.bai",
-    dst_dir="{sample.id}_{sample.last_run}",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S",
 )
 @output(
     "pipeline_info",
-    dst_name="{sample.id}_{sample.last_run}/pipeline_info/rnafusion",
+    dst_name="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/pipeline_info/rnafusion",
 )
 @runner(split_by="id")
 def rnafusion(

--- a/modules/rnaseq.py
+++ b/modules/rnaseq.py
@@ -88,12 +88,12 @@ def _add_optional_outputs(samples: Samples, config: Config) -> None:
         samples.output |= {
             OutputGlob(
                 src="star_salmon/salmon.merged.*",
-                dst_dir="{sample.id}_{sample.last_run}/expression/salmon/",
+                dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/salmon/",
                 dst_name=None,
             ),
             OutputGlob(
                 src="star_salmon/{sample.id}",
-                dst_dir="{sample.id}_{sample.last_run}/expression/salmon/",
+                dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/salmon/",
                 dst_name=None,
             ),
         }
@@ -102,22 +102,22 @@ def _add_optional_outputs(samples: Samples, config: Config) -> None:
         samples.output |= {
             OutputGlob(
                 src="star_salmon/rsem.merged.*",
-                dst_dir="{sample.id}_{sample.last_run}/expression/rsem/",
+                dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/rsem/",
                 dst_name=None,
             ),
             OutputGlob(
                 src="star_salmon/{sample.id}.genes.results",
-                dst_dir="{sample.id}_{sample.last_run}/expression/rsem/",
+                dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/rsem/",
                 dst_name=None,
             ),
             OutputGlob(
                 src="star_salmon/{sample.id}.isoforms.results",
-                dst_dir="{sample.id}_{sample.last_run}/expression/rsem/",
+                dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/rsem/",
                 dst_name=None,
             ),
             OutputGlob(
                 src="star_salmon/{sample.id}.stat",
-                dst_dir="{sample.id}_{sample.last_run}/expression/rsem/",
+                dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/rsem/",
                 dst_name=None,
             ),
         }
@@ -125,55 +125,55 @@ def _add_optional_outputs(samples: Samples, config: Config) -> None:
 
 @output(
     "{config.rnaseq.aligner}/{sample.id}.markdup.sorted.bam",
-    dst_dir="{sample.id}_{sample.last_run}/expression",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression",
 )
 @output(
     "{config.rnaseq.aligner}/{sample.id}.markdup.sorted.bam.bai",
-    dst_dir="{sample.id}_{sample.last_run}/expression",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression",
 )
 @output(
     "salmon",
-    dst_name="{sample.id}_{sample.last_run}/expression/salmon_pseudo",
+    dst_name="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/salmon_pseudo",
 )
 @output(
     "{config.rnaseq.aligner}/stringtie",
-    dst_dir="{sample.id}_{sample.last_run}/expression/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/",
 )
 @output(
     "{config.rnaseq.aligner}/bigwig",
-    dst_dir="{sample.id}_{sample.last_run}/expression/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/",
 )
 @output(
     "{config.rnaseq.aligner}/samtools_stats",
-    dst_dir="{sample.id}_{sample.last_run}/expression/qc/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/qc/",
 )
 @output(
     "{config.rnaseq.aligner}/picard_metrics",
-    dst_dir="{sample.id}_{sample.last_run}/expression/qc/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/qc/",
 )
 @output(
     "{config.rnaseq.aligner}/rseqc",
-    dst_dir="{sample.id}_{sample.last_run}/expression/qc/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/qc/",
 )
 @output(
     "{config.rnaseq.aligner}/qualimap",
-    dst_dir="{sample.id}_{sample.last_run}/expression/qc/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/qc/",
 )
 @output(
     "{config.rnaseq.aligner}/dupradar",
-    dst_dir="{sample.id}_{sample.last_run}/expression/qc/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/qc/",
 )
 @output(
     "{config.rnaseq.aligner}/deseq2_qc",
-    dst_dir="{sample.id}_{sample.last_run}/expression/qc/",
+    dst_dir="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/expression/qc/",
 )
 @output(
     "multiqc/{config.rnaseq.aligner}",
-    dst_name="{sample.id}_{sample.last_run}/multiqc",
+    dst_name="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/multiqc",
 )
 @output(
     "pipeline_info",
-    dst_name="{sample.id}_{sample.last_run}/pipeline_info/rnaseq",
+    dst_name="{sample.id}_{sample.last_run}_%y%m%d-%H%M%S/pipeline_info/rnaseq",
 )
 @runner(split_by="id")
 def rnaseq(


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @dodslaser 

### The What
Adding timestamp using Cellophane struct_time on rsynced output folder(s) in result dir.
Requires Cellophane [1.2.0.dev0](https://github.com/ClinicalGenomicsGBG/cellophane/commit/926db56370915ee03253dad3f1aa9262546ffd21)

### The Why
Avoid confusion on crashed samples and re-runs.

### The How
Added %y%m%d-%H%M%S to dst_dir wherever @output or OutputGlob is specified.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
Make sure you have updated Cellophane to commit [1.2.0.dev0](https://github.com/ClinicalGenomicsGBG/cellophane/commit/926db56370915ee03253dad3f1aa9262546ffd21) 

### Tests
Have run on two test samples. Timestamps were successfully added when rsynced to webstore.

### Expected outcome
Timestamps on the output folder(s) in resultsdir.

## Verifications
- [x] Code reviewed by @dodslaser 
- [x] Code tested by @fannyhb 
