### PR TITLE
Use paired end filenames to determine R1 and R2 for nextflow samplesheet

### DIFF
--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -36,8 +36,12 @@ def split_r1_r2(files, *, logger: LoggerAdapter | None = None, sample_id = None)
     """
     Strictly split a 2-file FASTQ pair into (R1, R2).
     """
-    if len(files) != 2:
-        raise ValueError(f"Expected exactly 2 FASTQ files for sample {sample_id!r}, got {len(files)}")
+    if len(files) == 1:
+        if logger:
+            logger.info(f"Only one FASTQ file found for sample {sample_id!r}, assuming single-end data.")
+        return str(files[0]), None
+    elif len(files) != 2:
+        raise ValueError(f"Expected either 1 (single-end) or 2 (paired-end) FASTQ files for sample {sample_id!r}, got {len(files)}")
 
     r1: str | None = None
     r2: str | None = None

--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -34,7 +34,10 @@ def _infer_read(path: str | Path) -> tuple[int | None, str]:
 
 def split_r1_r2(files, *, logger: LoggerAdapter | None = None, sample_id = None):
     """
-    Strictly split a 2-file FASTQ pair into (R1, R2).
+    Split a list of FASTQ files into (R1, R2).
+
+    Handles both single-end (returns (R1, None)) and paired-end (returns (R1, R2)) data.
+    Raises ValueError for unexpected file counts or ambiguous classification.
     """
     if len(files) == 1:
         if logger:

--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -15,21 +15,20 @@ def _infer_read(path: str | Path) -> tuple[int | None, str]:
     Infer read number (1 or 2) from filename tokens.
     Returns (read, how). If read is None, 'how' explains why.
     """
-    name = Path(path).name
+    name = Path(path).name  # Extract the filename only
 
-    for pat, how in ((_EXPLICIT, "explicit R1/R2 token"), (_NUMERIC, "numeric 1/2 token")):
-        last: int | None = None
+    # Try first explicit R1/R2 tokens, then bare 1/2 tokens.
+    for pattern, how in ((_EXPLICIT, "explicit R1/R2 token"), (_NUMERIC, "numeric 1/2 token")):
         seen: set[int] = set()
 
-        for m in pat.finditer(name):
-            val = int(m.group(1))
-            seen.add(val)
-            last = val
+        for match in pattern.finditer(name):
+            val = int(match.group(1))  # Extract the read number (1 or 2)
+            seen.add(val)  # within the set, multiple of the same value is fine
 
-        if last is not None:
-            if len(seen) > 1:
+        if seen:
+            if len(seen) > 1:  # E.g. both R1 and R2 found within one filename
                 return None, f"ambiguous: found both {sorted(seen)} via {how}"
-            return last, how
+            return next(iter(seen)), how
 
     return None, "no R1/R2 marker found"
 

--- a/modules/qlucore.py
+++ b/modules/qlucore.py
@@ -276,6 +276,7 @@ def qlucore(
         sample_sheet = samples.nfcore_samplesheet(
             location=workdir,
             strandedness=config.strandedness,
+            logger=logger,
         )
 
         nf_config(

--- a/modules/rnafusion.py
+++ b/modules/rnafusion.py
@@ -273,6 +273,7 @@ def rnafusion(
     sample_sheet = samples.nfcore_samplesheet(
         location=workdir,
         strandedness=config.strandedness,
+        logger=logger
     )
 
     nextflow(

--- a/modules/rnaseq.py
+++ b/modules/rnaseq.py
@@ -205,6 +205,7 @@ def rnaseq(
     sample_sheet = samples.nfcore_samplesheet(
         location=workdir,
         strandedness=config.strandedness,
+        logger=logger
     )
 
     nextflow(


### PR DESCRIPTION
### The What

Determine R1 / R2 paired end read files in nextflow module

### The Why

When building the samplesheet, the first fastq file should be R1, and the second R2, or else the pipeline (especially rnaseq) will not run correctly

### The How

- Capture the 1 or 2 from [delim]R1[delim] / [delim]R2[delim] in the first regex capture group
  - If both R1 and R2 are found in one filename, raise an error (e.g. `myfastq_R2_r1.fastq.gz`)
- If nothing is found, try with [delim]1[delim] / [delim]2[delim]
  - e.g. would determine `myfastq_2_001.fq.gz` as R2
- Log which file was determined as which paired end read file

Note: This (intentionally) does not allow for single end sequencing, since we are running qd-rna with paired end reads (and accidentally running with a single fastq would be wrong). Let me know if we should allow single end sequencing. 

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

Tested with a manual run. Verified that the paired end read files were determined correctly. 

Depending on the filenames one can imagine edge cases which should / should not work.
