### PR TITLE
fix: add bioconda to SpringExtractor conda dependencies

### DIFF
--- a/modules/unpack/src/extractors.py
+++ b/modules/unpack/src/extractors.py
@@ -121,7 +121,10 @@ class SpringExtractor(
     label="spring",
     script=Path(__file__).parent.parent / "scripts" / "spring.sh",
     suffixes=(".spring",),
-    conda_spec={"dependencies": ["spring >=1.1.1, <2.0.0"]},
+    conda_spec={
+        "channels": ["bioconda", "conda-forge"],
+        "dependencies": ["spring >=1.1.1, <2.0.0"]
+    },
 ):
     """Spring extractor."""
 


### PR DESCRIPTION
### The What

- Added bioconda to spring extractor conda dependencies
- NOTE: This change is also present in the cellophane_modules `unpack` module, however there are other larger changes there as well, outside the scope of this patch. Maybe in the future we can update the modules.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
