### PR TITLE
Add qdrna_env yaml

### DIFF
--- a/qdrna_env.yaml
+++ b/qdrna_env.yaml
@@ -1,0 +1,13 @@
+name: qdrna_env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip=26.0
+  - jinja2=3.1.6
+  - mistletoe=1.5.1
+  - uge-drmaa2=8.9.0
+  - pip:
+    - git+https://github.com/ClinicalGenomicsGBG/cellophane.git@1.2.0
+    - NGPIris==4.3.0
+    - slims-python-api==6.8.0


### PR DESCRIPTION
### The What

environment yaml of the necessary dependencies to run qd-rna

### The Why

- enable users to create an environment to run qd-rna
- start tracking used cellophane versions (and other tools)

### The How

- Add available Conda packages
- Add other packages with pip
- Note: Using later versions of `NGPIris` is currently not supported

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- Tested with a regular qd-rna run