### PR TITLE
Allow usage of credentials path for slims

### DIFF
--- a/modules/slims/schema.yaml
+++ b/modules/slims/schema.yaml
@@ -2,12 +2,11 @@ properties:
   slims:
     type: object
 
-    dependentRequired:
-      username: [password, url, find_criteria]
-      password: [username, url, find_criteria]
-      url: [username, password, find_criteria]
-
     properties:
+      credentials:
+        description: Path to YAML file containing SLIMS credentials (url/user/password)
+        type: string
+
       url:
         description: SLIMS URL
         type: string
@@ -65,3 +64,7 @@ properties:
         description: Do not sync data to SLIMS
         default: false
         type: boolean
+
+    anyOf:
+      - required: [credentials]
+      - required: [url, username, password]

--- a/modules/slims/src/hooks.py
+++ b/modules/slims/src/hooks.py
@@ -8,10 +8,9 @@ from warnings import warn
 from cellophane import Config, Samples, post_hook, pre_hook
 from humanfriendly import parse_timespan
 from slims.internal import Record
-from slims.slims import Slims
 
 from .mixins import SlimsSample, SlimsSamples
-from .util import get_records
+from .util import get_records, slims_from_config
 
 
 def _augment_sample(
@@ -46,21 +45,12 @@ def slims_fetch(
     **_,
 ) -> SlimsSamples | None:
     """Load novel samples from SLIMS."""
-    if any(w not in config.slims for w in ["url", "username", "password"]):
-        logger.warning("SLIMS connection not configured")
-        return None
-
     criteria: str
     if not (criteria := config.slims.get("criteria")):
         logger.warning("No SLIMS criteria - Skipping fetch")
         return None
 
-    slims_connection = Slims(
-        name=__package__,
-        url=config.slims.url,
-        username=config.slims.username,
-        password=config.slims.password,
-    )
+    slims_connection = slims_from_config(config, logger)
 
     if samples:
         logger.info("Augmenting existing samples with info from SLIMS")

--- a/modules/slims/src/mixins.py
+++ b/modules/slims/src/mixins.py
@@ -11,7 +11,7 @@ from cellophane.src.data import Container
 from cellophane.src.util import map_nested_keys
 from slims.slims import Record, Slims
 
-from .util import get_field, get_fields_from_sample, get_records
+from .util import get_field, get_fields_from_sample, get_records, slims_from_config
 
 
 @define(slots=False)
@@ -254,12 +254,8 @@ class SlimsSamples(Samples):
         **kwargs,
     ) -> "SlimsSamples":
         """Get samples from SLIMS records"""
-        _connection = connection or Slims(
-            name=__package__,
-            url=config.slims.url,
-            username=config.slims.username,
-            password=config.slims.password,
-        )
+        _connection = connection or slims_from_config(config)
+
         records = get_records(
             criteria=criteria,
             connection=_connection,

--- a/modules/slims/src/util.py
+++ b/modules/slims/src/util.py
@@ -4,7 +4,9 @@ import re
 from contextlib import suppress
 from functools import cache, reduce, singledispatch
 from json import loads
-from typing import Any
+from pathlib import Path
+from ruamel.yaml import safe_load
+from typing import Any, Optional
 from warnings import warn
 
 from attrs import define
@@ -27,6 +29,72 @@ from slims.criteria import (
 )
 from slims.criteria import _JunctionType as op
 from slims.slims import Record, Slims
+
+
+def _parse_slims_credentials(credentials: Path | str) -> tuple[str, str, str]:
+    """ 
+    Parse SLIMS credentials from a YAML file. The file must contain the following fields:
+    - url: The URL of the SLIMS instance
+    - user or username: The username to use for authentication
+    - password, pass, or pwd: The password to use for authentication
+
+    returns a tuple of (url, user, password)
+    """
+    credentials = Path(credentials)
+    if not credentials.is_file():
+        raise FileNotFoundError(f"Credentials file not found: {credentials}")
+    if credentials.suffix not in {".yaml", ".yml"}:
+        raise ValueError(f"Credentials file must be a YAML file: {credentials}")
+
+    creds = safe_load(credentials.read_text())
+
+    if not isinstance(creds, dict):
+        raise ValueError(f"Credentials YAML must be a mapping/object, got {type(creds).__name__}")
+
+        # Allow either top-level keys OR nested under "slims:"
+    if "slims" in creds and isinstance(creds["slims"], dict):
+        creds = creds["slims"]
+
+    url = creds.get("url")
+    username = creds.get("user") or creds.get("username")
+    password = creds.get("password") or creds.get("pass") or creds.get("pwd")
+
+    if not url or not username or not password:
+        raise ValueError("Credentials file must contain 'url', 'user', and 'password' fields")
+
+    return url, username, password
+
+
+def slims_from_config(config, logger=None) -> Slims:
+    """Get Slims connection from config (optionally via credentials file)."""
+
+    creds: dict[str, Optional[str]] = {"url": None, "username": None, "password": None}
+
+    # credentials file
+    cred_path = getattr(config.slims, "credentials", None)
+    if cred_path:
+        credentials_path = Path(cred_path)
+        if logger:
+            logger.debug(f"Using credentials from {credentials_path}")
+        creds["url"], creds["username"], creds["password"] = _parse_slims_credentials(credentials_path)
+
+    # overrides from config (only if provided / truthy)
+    for key in ("url", "username", "password"):
+        val = getattr(config.slims, key, None)
+        if val:
+            if creds[key] is not None and logger:
+                logger.info(f"Overriding SLIMS {key} from credentials with config value")
+            creds[key] = val
+
+    if not all([creds["url"], creds["username"], creds["password"]]):
+        raise ValueError("SLIMS connection not fully configured - Missing url, username, or password")
+
+    return Slims(
+        name=__package__,
+        url=creds["url"],
+        username=creds["username"],
+        password=creds["password"],
+    )
 
 
 @cache


### PR DESCRIPTION
### The What

Option to use a credentials yaml for slims instead of submitting the url, username and password in the config

### The Why

We would like to start tracking the config with git but will need to remove slims credentials

### The How

- Read url, user, pass from credentials file (if given)
- Overwrite with manual values (if given)

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


### Tests

- Testran a sample
