### PR TITLE
Fix: Missing Arriba dependency

### DIFF
--- a/modules/rnafusion.py
+++ b/modules/rnafusion.py
@@ -178,7 +178,7 @@ def _standalone_arriba_visualisation(
             },
             workdir=workdir,
             name=f"standalone_arriba_visualisation_{_id}",
-            conda_spec={"dependencies": [f"arriba ={version}", "samtools =1.16"],
+            conda_spec={"dependencies": [f"arriba ={version}", "samtools =1.16", "jq >=1.8"],
                         "channels": ["bioconda", "conda-forge"],},
             cpus=config.rnafusion.arriba_standalone.threads,
             **kwargs,


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What

* Added missing `jq` dependency to arriba environment

### The Why

Environment fails to build because arriba depends (indirectly) on `yq` which depends on `jq` but at one point the `jq` dependency got lost in one of the recipes.
This is meant to be a temporary fix until the `yq` recipe in conda-forge is fixed.
(cf https://github.com/conda-forge/yq-feedstock/pull/42)

### The How

* Added dependency to env spec in `rnafusion` runner

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat